### PR TITLE
Update to new Buffer.from API

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function SplitStream(deliminator, options){
 }
 
 SplitStream.prototype._transform = function(chunk, encoding, done){
-  chunk = Buffer.isBuffer(chunk) ? chunk : Buffer(chunk)
+  chunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
   var prevContentStarti = 0
   //console.log('\n=====================\n')
   for (var chunkIndex=0; chunkIndex < chunk.length; chunkIndex++) {
@@ -95,7 +95,7 @@ SplitStream.prototype._flush = function(callback){
 
 SplitStream.prototype.abortMaybeDelim = function(){
   if (this.maybeDelim.length) {
-    this.buffered.push(Buffer(this.maybeDelim))
+    this.buffered.push(Buffer.from(this.maybeDelim))
     this.maybeDelim = ''
   }
 }

--- a/test/delimit-stream.js
+++ b/test/delimit-stream.js
@@ -10,12 +10,12 @@ describe('SplitStream', function(){
     ss2 = new SplitStream('----', { objectMode:true })
     w = function() {
       Array.prototype.slice.call(arguments).forEach(function(foo) {
-        ss.write(Buffer(foo))
+        ss.write(Buffer.from(foo))
       })
     }
     w2 = function() {
       Array.prototype.slice.call(arguments).forEach(function(foo) {
-        ss2.write(Buffer(foo))
+        ss2.write(Buffer.from(foo))
       })
     }
   })
@@ -32,24 +32,24 @@ describe('SplitStream', function(){
     testUtil.shouldStreamDataTimes(ss, ['foo'])
   })
   it('works with Buffer chunks', function() {
-    ss.write(Buffer('foo\r\n'))
+    ss.write(Buffer.from('foo\r\n'))
     testUtil.shouldStreamDataTimes(ss, ['foo'])
   })
 
   describe('makes a stream output messages by breaking its data flow on a given deliminator of any length', function(){
     it('1 char deliminator \\n', function(done) {
       var ss = new SplitStream('\n', {objectMode:true})
-      ss.end(Buffer('foo\nbar\n'))
+      ss.end(Buffer.from('foo\nbar\n'))
       testUtil.shouldStreamDataTimes(ss, ['foo', 'bar'], done)
     })
     it('2 char deliminator \\r\\n', function(done) {
       var ss = new SplitStream('\r\n', {objectMode:true})
-      ss.end(Buffer('foo\r\nbar\r\n'))
+      ss.end(Buffer.from('foo\r\nbar\r\n'))
       testUtil.shouldStreamDataTimes(ss, ['foo', 'bar'], done)
     })
     it('3 char deliminator \\r\\n\\n', function(done) {
       var ss = new SplitStream('\r\n\n', {objectMode:true})
-      ss.end(Buffer('foo\r\n\nbar\r\n\n'))
+      ss.end(Buffer.from('foo\r\n\nbar\r\n\n'))
       testUtil.shouldStreamDataTimes(ss, ['foo', 'bar'], done)
     })
   })


### PR DESCRIPTION
The old `new Buffer` API was deprecated in Node v6.0.0 for security reasons. This PR replaces all those invocations with the new `Buffer.from` API.

Tests pass:

```
yarn run v1.21.1
$ ./node_modules/.bin/mocha --reporter spec
Done in 0.17s.
```